### PR TITLE
Copy one version of zip with filename that does not change.

### DIFF
--- a/DockerFiles/build_win.sh
+++ b/DockerFiles/build_win.sh
@@ -26,3 +26,4 @@ bash build.sh -m64 -j16 bdist
 
 # Copy compiled file to release folder mapped in docker image
 cp openslide-win64-*.zip ../release/
+cp openslide-win64-*.zip ../release/openslide-win64-latest.zip


### PR DESCRIPTION
Make it easier to use the output in scripts by also copying a version of the zip with a fixed filename. 