### PR TITLE
Set default behaviour when running Docker to run build_win.sh

### DIFF
--- a/DockerFiles/Dockerfile
+++ b/DockerFiles/Dockerfile
@@ -12,4 +12,4 @@ COPY build_win.sh /build
 COPY build_linux.sh /build
 COPY build_linux_deb.sh /build
 
-CMD ["bash"]
+CMD ["bash",  "build_win.sh"]

--- a/DockerFiles/build_win.sh
+++ b/DockerFiles/build_win.sh
@@ -26,4 +26,3 @@ bash build.sh -m64 -j16 bdist
 
 # Copy compiled file to release folder mapped in docker image
 cp openslide-win64-*.zip ../release/
-cp openslide-win64-*.zip ../release/openslide-win64-latest.zip


### PR DESCRIPTION
Default behavior is to run build_win.sh 